### PR TITLE
Changed entropy package.

### DIFF
--- a/analysis/calculate.entropy.R
+++ b/analysis/calculate.entropy.R
@@ -3,7 +3,7 @@
 #   Input is a directory containing one or more files with MiXCR output format
 #   
 #   Load necessary libraries
-library(tcR);
+library(entropy); # requires package "entropy" as well
 
 #	Get command-line arguments
 arguments <- commandArgs(trailingOnly=TRUE);
@@ -26,8 +26,7 @@ for(i in 1:length(files.in.dir))	{
     #   calculate entropy
     #   Note:  The library's code throw's warnings about the input not summing to 1, even
     #       though we're using the .do.norm parameter in the function call
-    calculated.entropies[i] <- entropy(curr.record$"Clone fraction",
-                                        .do.norm=TRUE);
+    calculated.entropies[i] <- entropy(curr.record$"Clone fraction", method="ML", unit="log");
 
     #   update progress
     if((i %%10) == 0)   {


### PR DESCRIPTION
Now imports the library "entropy" (from package "entropy"). Its function is still called entropy, as the tcr one was as well, but has extra parameters. See line 29, added method = "ML" (maximum likelihood) and unit="log" (natural log). This script now outputs what I was getting from using my homemade entropy calculation (see https://ohsu.app.box.com/files/0/f/6353451529/1/f_51969985913).