### PR TITLE
updated check for parallelization of samples (lines 25-29)

### DIFF
--- a/QC/normalization.QC.R
+++ b/QC/normalization.QC.R
@@ -24,8 +24,8 @@ sample.id.raw.clone.counts <- character(length(raw.clone.counts));
 sample.id.processed.clone.counts <- character(length(processed.clone.counts));
 #	TODO:  fix this, it relies on file naming convention
 for(i in 1:length(raw.clone.counts))  {
-    sample.id.raw.clone.counts[i] <- str_split(raw.clone.counts[i], "_")[[1]][1];
-    sample.id.processed.clone.counts[i] <- str_split(processed.clone.counts[i], "_")[[1]][1];
+    sample.id.raw.clone.counts[i] <- str_split(raw.clone.counts[i], "_")[[1]][2];
+    sample.id.processed.clone.counts[i] <- str_split(processed.clone.counts[i], "_")[[1]][2];
 }   #   for i
 
 #   Check for parallelism of files


### PR DESCRIPTION
Using [[1]][1] in str_split cuts the string to just DNA151124LC, so there is an array of 170 copies of that. Using [[1]][2] cuts the string to 1, 2, 3...170, which is what I assume is what we want so we can make sure we're taking clone counts and normalized clone counts from corresponding files.